### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/dev/api_docs.py
+++ b/dev/api_docs.py
@@ -84,14 +84,14 @@ def _get_func_info(docstring, def_lineno, code_lines, prefix):
     description = description.strip()
     description_md = ''
     if description:
-        description_md = "%s%s" % (prefix, description.replace("\n", "\n" + prefix))
+        description_md = "{0!s}{1!s}".format(prefix, description.replace("\n", "\n" + prefix))
         description_md = re.sub('\n>(\\s+)\n', '\n>\n', description_md)
 
     params = params.strip()
     if params:
-        definition += (':\n%s    """\n%s    ' % (prefix, prefix))
-        definition += params.replace('\n', '\n%s    ' % prefix)
-        definition += ('\n%s    """' % prefix)
+        definition += (':\n{0!s}    """\n{1!s}    '.format(prefix, prefix))
+        definition += params.replace('\n', '\n{0!s}    '.format(prefix))
+        definition += ('\n{0!s}    """'.format(prefix))
         definition = re.sub('\n>(\\s+)\n', '\n>\n', definition)
 
     for search, replace in definition_replacements.items():
@@ -263,7 +263,7 @@ def walk_ast(node, code_lines, sections, md_chunks):
                         class_docstring = ast.get_docstring(node) or ''
                         class_description = textwrap.dedent(class_docstring).strip()
                         if class_description:
-                            class_description_md = "> %s\n>" % (class_description.replace("\n", "\n> "))
+                            class_description_md = "> {0!s}\n>".format((class_description.replace("\n", "\n> ")))
                         else:
                             class_description_md = ''
 
@@ -312,7 +312,7 @@ def walk_ast(node, code_lines, sections, md_chunks):
                     key = attribute_key
 
                     description = textwrap.dedent(docstring).strip()
-                    description_md = "> > %s" % (description.replace("\n", "\n> > "))
+                    description_md = "> > {0!s}".format((description.replace("\n", "\n> > ")))
 
                     md_chunk = textwrap.dedent("""
                         >
@@ -420,7 +420,7 @@ def run():
 
         for key in sections:
             if key not in md_chunks:
-                raise ValueError('No documentation found for %s' % key[1])
+                raise ValueError('No documentation found for {0!s}'.format(key[1]))
             added_lines = _replace_md(key, sections, md_chunks[key], md_lines, added_lines)
 
         markdown = '\n'.join(md_lines).strip() + '\n'

--- a/dev/release.py
+++ b/dev/release.py
@@ -59,7 +59,7 @@ def run():
         ['sdist', 'bdist_wheel', '--universal']
     )
 
-    twine.cli.dispatch(['upload', 'dist/oscrypto-%s*' % tag])
+    twine.cli.dispatch(['upload', 'dist/oscrypto-{0!s}*'.format(tag)])
 
     setuptools.sandbox.run_setup(
         setup_file,

--- a/oscrypto/_ffi.py
+++ b/oscrypto/_ffi.py
@@ -139,14 +139,14 @@ try:
 
     def struct(library, name):
         ffi_obj = _get_ffi(library)
-        return ffi_obj.new('%s *' % name)
+        return ffi_obj.new('{0!s} *'.format(name))
 
     def struct_bytes(struct_):
         return ffi.buffer(struct_)[:]
 
     def struct_from_buffer(library, name, buffer):
         ffi_obj = _get_ffi(library)
-        new_struct_pointer = ffi_obj.new('%s *' % name)
+        new_struct_pointer = ffi_obj.new('{0!s} *'.format(name))
         new_struct = new_struct_pointer[0]
         struct_size = sizeof(library, new_struct)
         struct_buffer = ffi_obj.buffer(new_struct_pointer)
@@ -155,7 +155,7 @@ try:
 
     def array_from_pointer(library, name, point, size):
         ffi_obj = _get_ffi(library)
-        array = ffi_obj.cast('%s[%s]' % (name, size), point)
+        array = ffi_obj.cast('{0!s}[{1!s}]'.format(name, size), point)
         total_bytes = ffi_obj.sizeof(array)
         if total_bytes == 0:
             return []

--- a/oscrypto/_osx/_core_foundation.py
+++ b/oscrypto/_osx/_core_foundation.py
@@ -204,7 +204,7 @@ def handle_cf_error(error_pointer):
                 output = code_map[num]
 
         if not output:
-            output = '%s %s' % (domain, num)
+            output = '{0!s} {1!s}'.format(domain, num)
 
     raise OSError(output)
 

--- a/oscrypto/_osx/_core_foundation_cffi.py
+++ b/oscrypto/_osx/_core_foundation_cffi.py
@@ -197,8 +197,8 @@ class CFHelpers():
 
         dict_length = CoreFoundation.CFDictionaryGetCount(dictionary)
 
-        keys = new(CoreFoundation, 'CFTypeRef[%s]' % dict_length)
-        values = new(CoreFoundation, 'CFTypeRef[%s]' % dict_length)
+        keys = new(CoreFoundation, 'CFTypeRef[{0!s}]'.format(dict_length))
+        values = new(CoreFoundation, 'CFTypeRef[{0!s}]'.format(dict_length))
         CoreFoundation.CFDictionaryGetKeysAndValues(
             dictionary,
             keys,

--- a/oscrypto/_osx/_security.py
+++ b/oscrypto/_osx/_security.py
@@ -42,7 +42,7 @@ def handle_sec_error(error, exception_class=None):
     CoreFoundation.CFRelease(cf_error_string)
 
     if output is None or output == '':
-        output = 'OSStatus %s' % error
+        output = 'OSStatus {0!s}'.format(error)
 
     if exception_class is None:
         exception_class = OSError

--- a/oscrypto/_osx/_security_cffi.py
+++ b/oscrypto/_osx/_security_cffi.py
@@ -24,7 +24,7 @@ version = platform.mac_ver()[0]
 version_info = tuple(map(int, version.split('.')))
 
 if version_info < (10, 7):
-    raise OSError('Only OS X 10.7 and newer are supported, not %s.%s' % (version_info[0], version_info[1]))
+    raise OSError('Only OS X 10.7 and newer are supported, not {0!s}.{1!s}'.format(version_info[0], version_info[1]))
 
 ffi = FFI()
 ffi.cdef("""

--- a/oscrypto/_osx/_security_ctypes.py
+++ b/oscrypto/_osx/_security_ctypes.py
@@ -20,7 +20,7 @@ version = platform.mac_ver()[0]
 version_info = tuple(map(int, version.split('.')))
 
 if version_info < (10, 7):
-    raise OSError('Only OS X 10.7 and newer are supported, not %s.%s' % (version_info[0], version_info[1]))
+    raise OSError('Only OS X 10.7 and newer are supported, not {0!s}.{1!s}'.format(version_info[0], version_info[1]))
 
 security_path = find_library('Security')
 if not security_path:

--- a/oscrypto/_tls.py
+++ b/oscrypto/_tls.py
@@ -337,18 +337,18 @@ def raise_hostname(certificate, hostname):
 
     is_ip = re.match('^\\d+\\.\\d+\\.\\d+\\.\\d+$', hostname) or hostname.find(':') != -1
     if is_ip:
-        hostname_type = 'IP address %s' % hostname
+        hostname_type = 'IP address {0!s}'.format(hostname)
     else:
-        hostname_type = 'domain name %s' % hostname
-    message = 'Server certificate verification failed - %s does not match' % hostname_type
+        hostname_type = 'domain name {0!s}'.format(hostname)
+    message = 'Server certificate verification failed - {0!s} does not match'.format(hostname_type)
     valid_ips = ', '.join(certificate.valid_ips)
     valid_domains = ', '.join(certificate.valid_domains)
     if valid_domains:
-        message += ' valid domains: %s' % valid_domains
+        message += ' valid domains: {0!s}'.format(valid_domains)
     if valid_domains and valid_ips:
         message += ' or'
     if valid_ips:
-        message += ' valid IP addresses: %s' % valid_ips
+        message += ' valid IP addresses: {0!s}'.format(valid_ips)
     raise TLSVerificationError(message, certificate)
 
 
@@ -462,10 +462,10 @@ def raise_expired_not_yet_valid(certificate):
 
     if not_before > now:
         formatted_before = not_before.strftime('%Y-%m-%d %H:%M:%SZ')
-        message = 'Server certificate verification failed - certificate not valid until %s' % formatted_before
+        message = 'Server certificate verification failed - certificate not valid until {0!s}'.format(formatted_before)
     elif not_after < now:
         formatted_after = not_after.strftime('%Y-%m-%d %H:%M:%SZ')
-        message = 'Server certificate verification failed - certificate expired %s' % formatted_after
+        message = 'Server certificate verification failed - certificate expired {0!s}'.format(formatted_after)
 
     raise TLSVerificationError(message, certificate)
 
@@ -495,7 +495,7 @@ def raise_protocol_error(server_handshake_bytes):
     other_protocol = detect_other_protocol(server_handshake_bytes)
 
     if other_protocol:
-        raise TLSError('TLS protocol error - server responded using %s' % other_protocol)
+        raise TLSError('TLS protocol error - server responded using {0!s}'.format(other_protocol))
 
     raise TLSError('TLS protocol error - server responded using a different protocol')
 

--- a/oscrypto/_types.py
+++ b/oscrypto/_types.py
@@ -38,4 +38,4 @@ def type_name(value):
         cls = value.__class__
     if cls.__module__ in set(['builtins', '__builtin__']):
         return cls.__name__
-    return '%s.%s' % (cls.__module__, cls.__name__)
+    return '{0!s}.{1!s}'.format(cls.__module__, cls.__name__)

--- a/oscrypto/_win/_cng.py
+++ b/oscrypto/_win/_cng.py
@@ -58,7 +58,7 @@ def handle_error(error_num):
         BcryptConst.STATUS_INVALID_BUFFER_SIZE: 'The size of the buffer is invalid for the specified operation',
     }
 
-    output = 'NTSTATUS error 0x%0.2X' % error_num
+    output = 'NTSTATUS error 0x{0:0.2X}'.format(error_num)
 
     if error_num is not None and error_num in messages:
         output += ': ' + messages[error_num]

--- a/oscrypto/_win/_secur32.py
+++ b/oscrypto/_win/_secur32.py
@@ -53,7 +53,7 @@ def handle_error(result, exception_class=None):
     if exception_class is None:
         exception_class = OSError
 
-    raise exception_class(('SECURITY_STATUS error 0x%0.2X: ' % result) + error_string)
+    raise exception_class(('SECURITY_STATUS error 0x{0:0.2X}: '.format(result)) + error_string)
 
 
 class Secur32Const():

--- a/oscrypto/_win/asymmetric.py
+++ b/oscrypto/_win/asymmetric.py
@@ -1004,7 +1004,7 @@ def _interpret_dsa_key_blob(key_type, version, blob_struct, blob):
         g = int_from_bytes(blob[g_offset:public_offset])
 
     else:
-        raise ValueError('version must be 1 or 2, not %s' % repr(version))
+        raise ValueError('version must be 1 or 2, not {0!s}'.format(repr(version)))
 
     if key_type == 'public':
         public = int_from_bytes(blob[public_offset:private_offset])

--- a/oscrypto/_win/tls.py
+++ b/oscrypto/_win/tls.py
@@ -225,7 +225,7 @@ class TLSSession(object):
                 Secur32Const.CALG_SHA256,
             ])
 
-        alg_array = new(secur32, 'ALG_ID[%s]' % len(algs))
+        alg_array = new(secur32, 'ALG_ID[{0!s}]'.format(len(algs)))
         for index, alg in enumerate(algs):
             alg_array[index] = alg
 
@@ -477,7 +477,7 @@ class TLSSocket(object):
             A tuple of (SecBufferDesc pointer, SecBuffer array)
         """
 
-        buffers = new(secur32, 'SecBuffer[%d]' % number)
+        buffers = new(secur32, 'SecBuffer[{0:d}]'.format(number))
 
         for index in range(0, number):
             buffers[index].cbBuffer = 0

--- a/oscrypto/asymmetric.py
+++ b/oscrypto/asymmetric.py
@@ -446,7 +446,7 @@ def dump_openssl_private_key(private_key, passphrase):
 
         headers = OrderedDict()
         headers['Proc-Type'] = '4,ENCRYPTED'
-        headers['DEK-Info'] = 'AES-128-CBC,%s' % binascii.hexlify(iv).decode('ascii')
+        headers['DEK-Info'] = 'AES-128-CBC,{0!s}'.format(binascii.hexlify(iv).decode('ascii'))
 
         key_length = 16
         passphrase_bytes = passphrase.encode('utf-8')

--- a/oscrypto/kdf.py
+++ b/oscrypto/kdf.py
@@ -131,7 +131,7 @@ def pbkdf2_iteration_calculator(hash_algorithm, key_length, target_ms=100, quiet
         pbkdf2(hash_algorithm, password, salt, iterations, key_length)
         observed_ms = _get_elapsed(start)
         if not quiet:
-            print('%s iterations in %sms' % (iterations, observed_ms))
+            print('{0!s} iterations in {1!s}ms'.format(iterations, observed_ms))
         return 1.0 / target_ms * observed_ms
 
     # Measure the initial guess, then estimate how many iterations it would

--- a/tests/_unittest_compat.py
+++ b/tests/_unittest_compat.py
@@ -26,20 +26,20 @@ def patch():
 
 def _assert_less(self, a, b, msg=None):
     if not a < b:
-        standard_msg = '%s not less than %s' % (unittest.util.safe_repr(a), unittest.util.safe_repr(b))
+        standard_msg = '{0!s} not less than {1!s}'.format(unittest.util.safe_repr(a), unittest.util.safe_repr(b))
         self.fail(self._formatMessage(msg, standard_msg))
 
 
 def _assert_is_instance(self, obj, cls, msg=None):
     if not isinstance(obj, cls):
         if not msg:
-            msg = '%s is not an instance of %r' % (obj, cls)
+            msg = '{0!s} is not an instance of {1!r}'.format(obj, cls)
         self.fail(msg)
 
 
 def _assert_in(self, member, container, msg=None):
     if member not in container:
-        standard_msg = '%s not found in %s' % (unittest.util.safe_repr(member), unittest.util.safe_repr(container))
+        standard_msg = '{0!s} not found in {1!s}'.format(unittest.util.safe_repr(member), unittest.util.safe_repr(container))
         self.fail(self._formatMessage(msg, standard_msg))
 
 
@@ -88,7 +88,6 @@ class _AssertRaisesContext(object):
         expected_regexp = self.expected_regexp
         if not expected_regexp.search(str(exc_value)):
             raise self.failureException(
-                '"%s" does not match "%s"' %
-                (expected_regexp.pattern, str(exc_value))
+                '"{0!s}" does not match "{1!s}"'.format(expected_regexp.pattern, str(exc_value))
             )
         return True

--- a/tests/unittest_data.py
+++ b/tests/unittest_data.py
@@ -43,7 +43,7 @@ def data_decorator(cls):
             params = params[1:]
         else:
             data_name = num
-        expanded_name = 'test_%s_%s' % (name, data_name)
+        expanded_name = 'test_{0!s}_{1!s}'.format(name, data_name)
         # We used expanded variable names here since this line is present in
         # backtraces that are generated from test failures.
         generated_test_function = lambda self: original_function(self, *params)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:oscrypto?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:oscrypto?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
